### PR TITLE
fjerner keyargs false som vi innførte for å få paginering til å "fungere"

### DIFF
--- a/component/package.json
+++ b/component/package.json
@@ -2,7 +2,7 @@
   "name": "@navikt/arbeidsgiver-notifikasjon-widget",
   "description": "React component for notifikasjoner for arbeidsgivere",
   "repository": "github:navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/esm/lib/esm/index.d.ts",

--- a/component/src/api/graphql.tsx
+++ b/component/src/api/graphql.tsx
@@ -8,17 +8,7 @@ import {Query} from "./graphql-types";
 export const createClient = (uri: string, credentials?: string) =>
   new ApolloClient({
     uri,
-    cache: new InMemoryCache({
-      typePolicies: {
-        Query: {
-          fields: {
-            saker: {
-              keyArgs: false
-            },
-          },
-        },
-      },
-    }),
+    cache: new InMemoryCache(),
     credentials
   })
 


### PR DESCRIPTION


vi så litt på dette nå og fant ut at fetchMore egentlig er ment til infinite scroll paging uavhengig api parametere. Derfor bør man nok egentlig erstatte listen i merge funksjon i stedet for å sette keyargs til false.
Vi bruker ikke lenger fetchmore og derfor fjerner vi hele denne configen