### PR TITLE
tillatt at apollo opts overstyres i mock middleware

### DIFF
--- a/brukerapi-mock/notifikasjonMockMiddleware.js
+++ b/brukerapi-mock/notifikasjonMockMiddleware.js
@@ -173,9 +173,9 @@ const createApolloServer = (apolloServerOptions) => {
   const data = fs.readFileSync(path.join(__dirname, 'bruker.graphql'));
 
   return new ApolloServer({
-    ...apolloServerOptions,
     typeDefs: gql(data.toString()),
     mocks: mocks(),
+    ...apolloServerOptions,
   });
 }
 

--- a/brukerapi-mock/package-lock.json
+++ b/brukerapi-mock/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
-      "version": "5.4.4",
+      "version": "5.4.5",
       "license": "MIT",
       "dependencies": {
         "apollo-server": "^3.10.2",

--- a/brukerapi-mock/package.json
+++ b/brukerapi-mock/package.json
@@ -2,7 +2,7 @@
   "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
   "description": "Mocker graphql-endepunkt for brukerapi. Nyttig for utvikling av @navikt/arbeidsgiver-notifikasjon-widget.",
   "repository": "github:navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "license": "MIT",
   "main": "dist/notifikasjonMockMiddleware.js",
   "files": [

--- a/component/package-lock.json
+++ b/component/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@navikt/arbeidsgiver-notifikasjon-widget",
-      "version": "5.4.4",
+      "version": "5.4.5",
       "dependencies": {
         "@apollo/client": "3.6.9",
         "graphql": "^16.6.0"

--- a/component/package.json
+++ b/component/package.json
@@ -2,7 +2,7 @@
   "name": "@navikt/arbeidsgiver-notifikasjon-widget",
   "description": "React component for notifikasjoner for arbeidsgivere",
   "repository": "github:navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/esm/lib/esm/index.d.ts",


### PR DESCRIPTION
trengs for å kunne utvikle mot endringer i backend uten å bumpe widget osv
