### PR TITLE
more lenient peer dep to nav ds

### DIFF
--- a/brukerapi-mock/package-lock.json
+++ b/brukerapi-mock/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
-  "version": "6.2.2",
+  "version": "6.2.3-rc0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
-      "version": "6.2.2",
+      "version": "6.2.3-rc0",
       "license": "MIT",
       "dependencies": {
         "apollo-server": "^3.10.2",

--- a/brukerapi-mock/package-lock.json
+++ b/brukerapi-mock/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
-  "version": "6.2.3-rc0",
+  "version": "6.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
-      "version": "6.2.3-rc0",
+      "version": "6.2.3",
       "license": "MIT",
       "dependencies": {
         "apollo-server": "^3.10.2",

--- a/brukerapi-mock/package.json
+++ b/brukerapi-mock/package.json
@@ -2,7 +2,7 @@
   "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
   "description": "Mocker graphql-endepunkt for brukerapi. Nyttig for utvikling av @navikt/arbeidsgiver-notifikasjon-widget.",
   "repository": "github:navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "6.2.3-rc0",
+  "version": "6.2.3",
   "license": "MIT",
   "main": "dist/notifikasjonMockMiddleware.js",
   "files": [

--- a/brukerapi-mock/package.json
+++ b/brukerapi-mock/package.json
@@ -2,7 +2,7 @@
   "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
   "description": "Mocker graphql-endepunkt for brukerapi. Nyttig for utvikling av @navikt/arbeidsgiver-notifikasjon-widget.",
   "repository": "github:navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "6.2.2",
+  "version": "6.2.3-rc0",
   "license": "MIT",
   "main": "dist/notifikasjonMockMiddleware.js",
   "files": [

--- a/component/package-lock.json
+++ b/component/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "6.2.3-rc0",
+  "version": "6.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@navikt/arbeidsgiver-notifikasjon-widget",
-      "version": "6.2.3-rc0",
+      "version": "6.2.3",
       "dependencies": {
         "@apollo/client": "3.6.9",
         "graphql": "^16.6.0"

--- a/component/package-lock.json
+++ b/component/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "6.2.2",
+  "version": "6.2.3-rc0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@navikt/arbeidsgiver-notifikasjon-widget",
-      "version": "6.2.2",
+      "version": "6.2.3-rc0",
       "dependencies": {
         "@apollo/client": "3.6.9",
         "graphql": "^16.6.0"
@@ -34,9 +34,9 @@
         "typescript": "^4.8.4"
       },
       "peerDependencies": {
-        "@navikt/ds-css": "2 || 3",
-        "@navikt/ds-icons": "2 || 3",
-        "@navikt/ds-react": "2 || 3",
+        "@navikt/ds-css": ">=2",
+        "@navikt/ds-icons": ">=2",
+        "@navikt/ds-react": ">=2",
         "react": "17",
         "react-dom": "17"
       }

--- a/component/package.json
+++ b/component/package.json
@@ -2,7 +2,7 @@
   "name": "@navikt/arbeidsgiver-notifikasjon-widget",
   "description": "React component for notifikasjoner for arbeidsgivere",
   "repository": "github:navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "6.2.3-rc0",
+  "version": "6.2.3",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/esm/lib/esm/index.d.ts",

--- a/component/package.json
+++ b/component/package.json
@@ -2,7 +2,7 @@
   "name": "@navikt/arbeidsgiver-notifikasjon-widget",
   "description": "React component for notifikasjoner for arbeidsgivere",
   "repository": "github:navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "6.2.2",
+  "version": "6.2.3-rc0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/esm/lib/esm/index.d.ts",
@@ -42,8 +42,8 @@
   "peerDependencies": {
     "react": "17",
     "react-dom": "17",
-    "@navikt/ds-css": "2 || 3",
-    "@navikt/ds-icons": "2 || 3",
-    "@navikt/ds-react": "2 || 3"
+    "@navikt/ds-css": ">=2",
+    "@navikt/ds-icons": ">=2",
+    "@navikt/ds-react": ">=2"
   }
 }


### PR DESCRIPTION
Endrer peer dep til minimum 2 på nav ds pakkene. 

- [x] testet OK via min-side-arbeidsgiver

Fikser at de som har versjon 4 av `@navikt/ds-*` får denne feilen:
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @navikt/arbeidsgiver-notifikasjon-widget@6.2.2
npm ERR! Found: @navikt/ds-css@4.9.0
npm ERR! node_modules/@navikt/ds-css
npm ERR!   @navikt/ds-css@"^4.9.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @navikt/ds-css@"2 || 3" from @navikt/arbeidsgiver-notifikasjon-widget@6.2.2
npm ERR! node_modules/@navikt/arbeidsgiver-notifikasjon-widget
npm ERR!   @navikt/arbeidsgiver-notifikasjon-widget@"6.2.2" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: @navikt/ds-css@3.4.2
npm ERR! node_modules/@navikt/ds-css
npm ERR!   peer @navikt/ds-css@"2 || 3" from @navikt/arbeidsgiver-notifikasjon-widget@6.2.2
npm ERR!   node_modules/@navikt/arbeidsgiver-notifikasjon-widget
npm ERR!     @navikt/arbeidsgiver-notifikasjon-widget@"6.2.2" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! 

```