### PR TITLE
fikser JSON.parse error som følge av http 401 i apollo client

### DIFF
--- a/brukerapi-mock/package-lock.json
+++ b/brukerapi-mock/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
-      "version": "6.4.0",
+      "version": "6.4.1",
       "license": "MIT",
       "dependencies": {
         "apollo-server": "^3.10.2",

--- a/brukerapi-mock/package.json
+++ b/brukerapi-mock/package.json
@@ -2,7 +2,7 @@
   "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
   "description": "Mocker graphql-endepunkt for brukerapi. Nyttig for utvikling av @navikt/arbeidsgiver-notifikasjon-widget.",
   "repository": "github:navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "license": "MIT",
   "main": "dist/notifikasjonMockMiddleware.js",
   "files": [

--- a/component/package-lock.json
+++ b/component/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@navikt/arbeidsgiver-notifikasjon-widget",
-      "version": "6.4.0",
+      "version": "6.4.1",
       "dependencies": {
         "@apollo/client": "3.8.5",
         "graphql": "^16.8.1"

--- a/component/package-lock.json
+++ b/component/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@navikt/arbeidsgiver-notifikasjon-widget",
       "version": "6.4.0",
       "dependencies": {
-        "@apollo/client": "3.6.9",
+        "@apollo/client": "3.8.5",
         "graphql": "^16.8.1"
       },
       "devDependencies": {
@@ -118,18 +118,19 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.6.9.tgz",
-      "integrity": "sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.5.tgz",
+      "integrity": "sha512-/ueWC3f1pFeH+tWbM1phz6pzUGGijyml6oQ+LKUcQzpXF6tVFPrb6oUIUQCbZpr6Xmv/dtNiFDohc39ra7Solg==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/context": "^0.6.0",
-        "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
+        "@wry/context": "^0.7.3",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.4.3",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
+        "optimism": "^0.17.5",
         "prop-types": "^15.7.2",
+        "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
         "ts-invariant": "^0.10.3",
         "tslib": "^2.3.0",
@@ -139,6 +140,7 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
         "graphql-ws": "^5.5.5",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
       },
       "peerDependenciesMeta": {
@@ -146,6 +148,9 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "react-dom": {
           "optional": true
         },
         "subscriptions-transport-ws": {
@@ -3029,9 +3034,9 @@
       }
     },
     "node_modules/@wry/context": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
+      "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3040,9 +3045,9 @@
       }
     },
     "node_modules/@wry/equality": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
-      "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.6.tgz",
+      "integrity": "sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3051,9 +3056,9 @@
       }
     },
     "node_modules/@wry/trie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
-      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -6126,12 +6131,13 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.5.tgz",
+      "integrity": "sha512-TEcp8ZwK1RczmvMnvktxHSF2tKgMWjJ71xEFGX5ApLh67VsMSTy1ZUlipJw8W+KaqgOmQ+4pqwkeivY89j+4Vw==",
       "dependencies": {
-        "@wry/context": "^0.6.0",
-        "@wry/trie": "^0.3.0"
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.4.3",
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/ora": {
@@ -7296,6 +7302,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/restore-cursor": {
@@ -8491,18 +8505,19 @@
       }
     },
     "@apollo/client": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.6.9.tgz",
-      "integrity": "sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.5.tgz",
+      "integrity": "sha512-/ueWC3f1pFeH+tWbM1phz6pzUGGijyml6oQ+LKUcQzpXF6tVFPrb6oUIUQCbZpr6Xmv/dtNiFDohc39ra7Solg==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/context": "^0.6.0",
-        "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
+        "@wry/context": "^0.7.3",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.4.3",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
+        "optimism": "^0.17.5",
         "prop-types": "^15.7.2",
+        "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
         "ts-invariant": "^0.10.3",
         "tslib": "^2.3.0",
@@ -10736,25 +10751,25 @@
       }
     },
     "@wry/context": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
+      "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@wry/equality": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
-      "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.6.tgz",
+      "integrity": "sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@wry/trie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
-      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -13080,12 +13095,13 @@
       }
     },
     "optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.5.tgz",
+      "integrity": "sha512-TEcp8ZwK1RczmvMnvktxHSF2tKgMWjJ71xEFGX5ApLh67VsMSTy1ZUlipJw8W+KaqgOmQ+4pqwkeivY89j+4Vw==",
       "requires": {
-        "@wry/context": "^0.6.0",
-        "@wry/trie": "^0.3.0"
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.4.3",
+        "tslib": "^2.3.0"
       }
     },
     "ora": {
@@ -13880,6 +13896,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw=="
     },
     "restore-cursor": {
       "version": "3.1.0",

--- a/component/package.json
+++ b/component/package.json
@@ -14,7 +14,7 @@
     "test": "echo tests not implemented"
   },
   "dependencies": {
-    "@apollo/client": "3.6.9",
+    "@apollo/client": "3.8.5",
     "graphql": "^16.8.1"
   },
   "devDependencies": {

--- a/component/package.json
+++ b/component/package.json
@@ -2,7 +2,7 @@
   "name": "@navikt/arbeidsgiver-notifikasjon-widget",
   "description": "React component for notifikasjoner for arbeidsgivere",
   "repository": "github:navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/esm/lib/esm/index.d.ts",

--- a/component/src/api/graphql.tsx
+++ b/component/src/api/graphql.tsx
@@ -5,7 +5,21 @@ import {RetryLink} from "@apollo/client/link/retry";
 export const createClient = (uri: string) =>
   new ApolloClient({
     cache: new InMemoryCache(),
-    link: from([new RetryLink(), new HttpLink({uri})]),
+    link: from([
+      new RetryLink({
+        attempts: {
+          max: 25,
+          retryIf: (error, _operation) => {
+            if (error.statusCode === 401) {
+              // do not retry 401
+              return false;
+            }
+            return !!error;
+          }
+        }
+      }),
+      new HttpLink({uri}),
+    ]),
   })
 
 export const HENT_NOTIFIKASJONER: TypedDocumentNode<Pick<Query, "notifikasjoner">> = gql`


### PR DESCRIPTION
ref: https://sentry.gc.nav.no/organizations/nav/issues/514864/?project=27

den egentlige feilen kommer fra en 401 i useSaker som forsøkes parses til json internt i apollo-client.
feilen kommer av at response parses etter retries er exhausted. Slik at vi ikke får en rapport om at det er 401, men at json parse feiler på en 401 respons.

i 3.7 av apollo client så forbedret de feilhåndteringen slik at den opprinnelige feilen ikke forsvinner pga parse feil: https://github.com/apollographql/apollo-client/pull/10018/files#diff-d180d739ac5085e3556db4fb80641f30389c9958f0eb702e88475d6253506e18

vi stopper polling i widget dersom det er 401, så jeg la til en commit som kortslutter retries dersom det er 401
økte også antall retries. tror default er 5. 